### PR TITLE
disable BTn

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,24 +51,23 @@ branch -d'
 alias gbd-remote='git branch -r --merged origin/main | grep -v "origin/main" |
 sed "s/origin\///" |$
 
-//================ Home =================// 
-styles
- //=================== SignUpPage ============//
+//================ Home =================// styles //===================
+SignUpPage ============//
 
 - sign up btn +/-
 - mobile
 - tablet
 - desctop
-- rendering components /
-/============= SignInPage =============//
- ❗ mobile 
- ❗ tablet 
- ❗ desctop
-   //=============== TrackerPage =============// aquatrack
-  image WaterProgressBar +/-
+- rendering components / /============= SignInPage =============//
 
-- addWaterBtn, editWaterBtn, deleteWaterBtn logOutBtn- do not open modals
--NEW UserSettingsForm(distance between the components, background-color,  ❗ desctop) +/-
+* mobile
+* tablet
+* desctop //=============== TrackerPage =============// aquatrack image
+  WaterProgressBar +/-
+
+- addWaterBtn, editWaterBtn, deleteWaterBtn logOutBtn- do not open modals -NEW
+  UserSettingsForm(distance between the components, background-color, ❗
+  desctop) +/-
 
 WaterList +/-
 
@@ -76,8 +75,5 @@ UserBarPopover: UserBar +/-
 
 Calendar +/- CalendarItem +/-
 
-//=============== Modals ===============// 
-DeleteWaterModal
- LogOutModal +/-
-NEW WaterModal +/-
-
+//=============== Modals ===============// DeleteWaterModal LogOutModal +/- NEW
+WaterModal +/-

--- a/src/components/Users/SignInForm/SignInForm.jsx
+++ b/src/components/Users/SignInForm/SignInForm.jsx
@@ -1,11 +1,9 @@
 import css from './signInForm.module.css';
-
 import { useState } from 'react';
 import { useDispatch } from 'react-redux';
 import { useForm } from 'react-hook-form';
 import { useNavigate } from 'react-router-dom';
 import { yupResolver } from '@hookform/resolvers/yup';
-
 import * as Yup from 'yup';
 import toast from 'react-hot-toast';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -24,15 +22,17 @@ const SignInForm = () => {
   const validationSchema = Yup.object().shape({
     email: Yup.string().email('Email is invalid').required('Email is required'),
     password: Yup.string()
-      .min(3, 'Password must be at least 6 characters')
+      .min(6, 'Password must be at least 6 characters')
       .required('Password is required'),
   });
 
   const {
     register,
     handleSubmit,
-    formState: { errors },
+    reset,
+    formState: { errors, isDirty, isValid },
   } = useForm({
+    mode: 'onChange',
     resolver: yupResolver(validationSchema),
   });
 
@@ -41,10 +41,11 @@ const SignInForm = () => {
       .unwrap()
       .then(res => {
         toast.success(res.message);
+        reset();
         navigate('/tracker');
       })
       .catch(err => {
-        toast.error(err.message);
+        toast.error('Email or password is incorrect, please try again!');
       });
   };
 
@@ -85,7 +86,11 @@ const SignInForm = () => {
               </div>
               {errors.password && <p>{errors.password.message}</p>}
             </div>
-            <Button addClass={css.btnform} type="submit">
+            <Button
+              disabled={!isDirty || !isValid}
+              addClass={css.btnform}
+              type="submit"
+            >
               Sign In
             </Button>
             <div className={css.spanSignIn}>

--- a/src/components/Users/SignInForm/signInForm.module.css
+++ b/src/components/Users/SignInForm/signInForm.module.css
@@ -52,7 +52,6 @@
   background-color: #f0eff4;
 }
 
-
 .formTitle {
   margin-bottom: 20px;
   color: #323f47;
@@ -62,7 +61,6 @@
   letter-spacing: -0.01em;
   margin-bottom: 32px;
 }
-
 
 .inputContainer {
   margin-bottom: 16px;
@@ -156,6 +154,17 @@
   background-color: #87d28d;
 }
 
+/* Додайте ці стилі для неактивної кнопки */
+.btnform:disabled {
+  cursor: not-allowed;
+  opacity: 0.5;
+}
+
+.btnform:disabled:hover,
+.btnform:disabled:focus {
+  transform: scale(1); /* Відміняє збільшення при наведенні */
+}
+
 @media (min-width: 768px) {
   .formSection {
     padding: 32px;
@@ -175,7 +184,6 @@
   .form {
     min-width: 436px;
     height: auto;
-
     padding: 227px 102px;
   }
 }


### PR DESCRIPTION
Санйн Ін - сторінка адаптована під всі 3 переломи

Вроді все зроблено по тз та по макету 

Кнопка задізейблена до моменту поки користувач не введе валідних даних - тільки тоді можна засабмітити форму тому до запомвнення форми запити на сервер не йдуть

В разі невірних даних тост виводить інфу але просто звичайне смс що щось не так ввели, бо якшо залишити так

  .catch(err => {
        toast.error(err.message);
      });

то просто буде чорний невеликий пустий квадратик і все ..  я хз як то пофіксити

а і ще одне теж не можу зрозуміти чого так працює бо до вчора все було ок. а коли сів сьогодні доробляти і стягнув актуальний мейн - то вже ні, отже-  коли на сторінц сайнІн тикаю той кастомний лінк 

 <CustomNavLink addClass={css.link} to="/signup">
                Sign Up
              </CustomNavLink>
              
              то він мусить редіректнути на сайнАП а воно перекидає на трекер одразу - теж хз чого так, причому це одразу так на мейні - може десь хтось шось крутив з маршрутизацією ( бо можна одразу на мейні чекнути і буде вже редірект куди попало) 
